### PR TITLE
feat: Add submissions endpoint for participant registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Dependencies
+/node_modules
+/.pnpm
+/pnpm-lock.yaml
+
+# Local development
+.env
+.wrangler/
+/coverage
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# OS
+.DS_Store
+Thumbs.db

--- a/migrations/0002_add_submissions_table.sql
+++ b/migrations/0002_add_submissions_table.sql
@@ -1,0 +1,21 @@
+-- migration for submissions table
+CREATE TABLE submissions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  registration_id TEXT NOT NULL UNIQUE,
+  full_name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  contact_number TEXT NOT NULL,
+  institution TEXT NOT NULL,
+  research_title TEXT NOT NULL,
+  bionote TEXT NOT NULL,
+  co_authors TEXT,
+  keywords TEXT NOT NULL,
+  status TEXT NOT NULL,
+  submitted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  abstract_name TEXT NOT NULL,
+  abstract_html_url TEXT NOT NULL,
+  abstract_download_url TEXT NOT NULL,
+  proof_of_payment_name TEXT NOT NULL,
+  proof_of_payment_html_url TEXT NOT NULL,
+  proof_of_payment_download_url TEXT NOT NULL
+);

--- a/src/endpoints/submissions/base.ts
+++ b/src/endpoints/submissions/base.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+export const submission = z.object({
+  id: z.number().int(),
+  registration_id: z.string(),
+  full_name: z.string(),
+  email: z.string().email(),
+  contact_number: z.string(),
+  institution: z.string(),
+  research_title: z.string(),
+  bionote: z.string(),
+  co_authors: z.string().optional(),
+  keywords: z.string(),
+  status: z.string(),
+  submitted_at: z.string().datetime(),
+  abstract_name: z.string(),
+  abstract_html_url: z.string(),
+  abstract_download_url: z.string(),
+  proof_of_payment_name: z.string(),
+  proof_of_payment_html_url: z.string(),
+  proof_of_payment_download_url: z.string(),
+});
+
+export const SubmissionModel = {
+  tableName: "submissions",
+  primaryKeys: ["id"],
+  schema: submission,
+  serializer: (obj: Record<string, string | number | boolean>) => {
+    return {
+      ...obj,
+    };
+  },
+  serializerObject: submission,
+};

--- a/src/endpoints/submissions/router.ts
+++ b/src/endpoints/submissions/router.ts
@@ -1,0 +1,7 @@
+import { Hono } from "hono";
+import { fromHono } from "chanfana";
+import { SubmissionCreate } from "./submissionCreate";
+
+export const submissionsRouter = fromHono(new Hono());
+
+submissionsRouter.post("/", SubmissionCreate);

--- a/src/endpoints/submissions/submissionCreate.ts
+++ b/src/endpoints/submissions/submissionCreate.ts
@@ -1,0 +1,79 @@
+import { OpenAPIRoute, contentJson } from 'chanfana';
+import { z } from 'zod';
+import { AppContext } from '../../types';
+import { uploadToGitHub } from '../../lib/github-upload';
+import { SubmissionModel } from './base';
+
+const RegisterParticipantInputSchema = z.object({
+  fullName: z.string(),
+  email: z.string().email(),
+  contactNumber: z.string(),
+  institution: z.string(),
+  researchTitle: z.string(),
+  bionote: z.string(),
+  coAuthors: z.string().optional(),
+  keywords: z.string(),
+  abstractFileDataUri: z.string().describe("The abstract file as a data URI."),
+  abstractFileName: z.string(),
+  proofOfPaymentDataUri: z.string().describe("The proof of payment file as a data URI."),
+  proofOfPaymentFileName: z.string(),
+});
+
+const RegisterParticipantOutputSchema = z.object({
+  registrationId: z.string(),
+  message: z.string(),
+});
+
+export class SubmissionCreate extends OpenAPIRoute {
+  schema = {
+    request: {
+      body: contentJson(RegisterParticipantInputSchema),
+    },
+    responses: {
+      '201': {
+        description: 'Submission created successfully',
+        ...contentJson(RegisterParticipantOutputSchema),
+      },
+    },
+  };
+
+  async handle(c: AppContext) {
+    const { body } = await this.getValidatedData<typeof this.schema>();
+
+    const registrationId = `PACUIT2025-${Date.now()}`;
+
+    // Upload files
+    const abstractUpload = await uploadToGitHub(body.abstractFileDataUri.split("base64,")[1], body.abstractFileName, registrationId, c.env);
+    const paymentUpload = await uploadToGitHub(body.proofOfPaymentDataUri.split("base64,")[1], body.proofOfPaymentFileName, registrationId, c.env);
+
+    // Save to D1
+    const db = c.env.DB;
+    const stmt = db.prepare(
+      `INSERT INTO ${SubmissionModel.tableName} (registration_id, full_name, email, contact_number, institution, research_title, bionote, co_authors, keywords, status, abstract_name, abstract_html_url, abstract_download_url, proof_of_payment_name, proof_of_payment_html_url, proof_of_payment_download_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      registrationId,
+      body.fullName,
+      body.email,
+      body.contactNumber,
+      body.institution,
+      body.researchTitle,
+      body.bionote,
+      body.coAuthors || 'N/A',
+      body.keywords,
+      'Pending Review',
+      body.abstractFileName,
+      abstractUpload.html_url,
+      abstractUpload.download_url,
+      body.proofOfPaymentFileName,
+      paymentUpload.html_url,
+      paymentUpload.download_url
+    );
+
+    await stmt.run();
+
+    return {
+      registrationId,
+      message: 'Registration successful. Please check your email for confirmation.',
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { ApiException, fromHono } from "chanfana";
 import { Hono } from "hono";
 import { tasksRouter } from "./endpoints/tasks/router";
+import { submissionsRouter } from "./endpoints/submissions/router";
 import { ContentfulStatusCode } from "hono/utils/http-status";
 import { DummyEndpoint } from "./endpoints/dummyEndpoint";
 
@@ -42,6 +43,9 @@ const openapi = fromHono(app, {
 
 // Register Tasks Sub router
 openapi.route("/tasks", tasksRouter);
+
+// Register Submissions Sub router
+openapi.route("/submissions", submissionsRouter);
 
 // Register other endpoints
 openapi.post("/dummy/:slug", DummyEndpoint);

--- a/src/lib/github-upload.ts
+++ b/src/lib/github-upload.ts
@@ -1,0 +1,47 @@
+export interface GitHubUploadEnv {
+    GITHUB_TOKEN: string;
+    GITHUB_OWNER: string;
+    GITHUB_REPO: string;
+    GITHUB_UPLOAD_PATH: string;
+}
+
+export async function uploadToGitHub(
+    fileContent: string,
+    fileName: string,
+    registrationId: string,
+    env: GitHubUploadEnv
+) {
+    const { GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO, GITHUB_UPLOAD_PATH } = env;
+
+    if (!GITHUB_TOKEN || !GITHUB_OWNER || !GITHUB_REPO || !GITHUB_UPLOAD_PATH) {
+        throw new Error("Missing GitHub configuration in environment variables.");
+    }
+
+    const path = `${GITHUB_UPLOAD_PATH}/${registrationId}/${fileName}`;
+    const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${path}`;
+
+    const response = await fetch(url, {
+        method: 'PUT',
+        headers: {
+            'Authorization': `token ${GITHUB_TOKEN}`,
+            'User-Agent': 'Chanfana-App',
+            'Accept': 'application/vnd.github.v3+json',
+        },
+        body: JSON.stringify({
+            message: `Upload ${fileName} for ${registrationId}`,
+            content: fileContent,
+        }),
+    });
+
+    if (!response.ok) {
+        const errorBody = await response.text();
+        console.error(`GitHub API error: ${response.status} ${response.statusText}`, errorBody);
+        throw new Error(`Failed to upload file to GitHub: ${fileName}`);
+    }
+
+    const data = await response.json();
+    return {
+        html_url: data.content.html_url,
+        download_url: data.content.download_url,
+    };
+}


### PR DESCRIPTION
This commit introduces a new endpoint for handling participant registrations. It converts the logic from a provided Firebase-based implementation to use the existing `chanfana` and D1 database stack.

The new functionality includes:
- A `/submissions` POST endpoint to receive registration data.
- A database migration to create a `submissions` table in the D1 database.
- A `Submission` model and Zod schema for data validation.
- A utility function to upload files (abstract and proof of payment) to a configured GitHub repository.
- Registration of the new endpoint with the Hono router and OpenAPI documentation.

The implementation follows the existing patterns for creating endpoints in the project.

Note: No new tests have been added for this endpoint. The existing test suite passes.