### PR TITLE
feat: add endpoint for institutional membership applications

### DIFF
--- a/src/endpoints/memberships/institutionalMembershipCreate.ts
+++ b/src/endpoints/memberships/institutionalMembershipCreate.ts
@@ -1,0 +1,101 @@
+import { OpenAPIRoute, contentJson } from 'chanfana';
+import { z } from 'zod';
+import { AppContext } from '../../types';
+import { uploadToGitHub } from '../../lib/github-upload';
+import { getDb } from "../../lib/firestore";
+
+const InputSchema = z.object({
+    institutionName: z.string().min(2),
+    contactPerson:  z.string().min(2),
+    email:          z.string().email(),
+    contactNumber:  z.string().min(10),
+
+    // data URIs and filenames
+    letterOfIntentUri:    z.string().startsWith('data:'),
+    letterOfIntentName:   z.string().min(1),
+    registrationUri:      z.string().startsWith('data:'),
+    registrationName:     z.string().min(1),
+    facultyListUri:       z.string().startsWith('data:'),
+    facultyListName:      z.string().min(1),
+    applicationFormUri:   z.string().startsWith('data:'),
+    applicationFormName:  z.string().min(1),
+});
+
+const OutputSchema = z.object({
+    applicationId: z.string(),
+    message: z.string(),
+});
+
+export class InstitutionalMembershipCreate extends OpenAPIRoute {
+    schema = {
+        request: {
+            body: contentJson(InputSchema),
+        },
+        responses: {
+            '201': {
+                description: 'Institutional membership application created successfully',
+                ...contentJson(OutputSchema),
+            },
+        },
+    };
+
+    async handle(c: AppContext) {
+        const { body } = await this.getValidatedData<typeof this.schema>();
+
+        const {
+            institutionName,
+            contactPerson,
+            email,
+            contactNumber,
+            letterOfIntentUri,
+            letterOfIntentName,
+            registrationUri,
+            registrationName,
+            facultyListUri,
+            facultyListName,
+            applicationFormUri,
+            applicationFormName,
+        } = body;
+
+        const applicationId = `PACUIT-INST-${Date.now()}`;
+
+        const uploadFromDataUri = async (uri: string, filename: string) => {
+            const [, base64] = uri.split(',');
+            return uploadToGitHub(base64, filename, applicationId, c.env);
+        }
+
+        const [
+            letterUpload,
+            regUpload,
+            facultyUpload,
+            appFormUpload,
+        ] = await Promise.all([
+            uploadFromDataUri(letterOfIntentUri, letterOfIntentName),
+            uploadFromDataUri(registrationUri, registrationName),
+            uploadFromDataUri(facultyListUri, facultyListName),
+            uploadFromDataUri(applicationFormUri, applicationFormName),
+        ]);
+
+        const db = getDb(c.env);
+        await db.collection('institutionalMemberships').add({
+            applicationId,
+            institutionName,
+            contactPerson,
+            email,
+            contactNumber,
+            status: 'Pending',
+            submittedAt: new Date().toISOString(),
+            documents: [
+                { name: 'Letter of Intent', ...letterUpload },
+                { name: 'SEC/CDA Registration', ...regUpload },
+                { name: 'Faculty List', ...facultyUpload },
+                { name: 'Application Form', ...appFormUpload },
+            ],
+        });
+
+        return c.json({
+            applicationId,
+            message: 'Application submitted successfully.',
+        }, 201);
+    }
+}

--- a/src/endpoints/memberships/router.ts
+++ b/src/endpoints/memberships/router.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { IndividualMembershipCreate } from "./individualMembershipCreate";
+import { InstitutionalMembershipCreate } from "./institutionalMembershipCreate";
 
 export const membershipsRouter = fromHono(new Hono());
 
 membershipsRouter.post("/individual", IndividualMembershipCreate);
+membershipsRouter.post("/institutional", InstitutionalMembershipCreate);

--- a/tests/integration/memberships.test.ts
+++ b/tests/integration/memberships.test.ts
@@ -71,4 +71,39 @@ describe("Memberships API Integration Tests", () => {
             expect(db.collection).toHaveBeenCalledWith("individualMemberships");
         });
     });
+
+    describe("POST /memberships/institutional", () => {
+        it("should create a new institutional membership application successfully", async () => {
+            const applicationData = {
+                institutionName: "Test University",
+                contactPerson: "Jane Doe",
+                email: "jane.doe@example.com",
+                contactNumber: "0987654321",
+                letterOfIntentUri: "data:application/pdf;base64,dGVzdA==",
+                letterOfIntentName: "letter.pdf",
+                registrationUri: "data:application/pdf;base64,dGVzdA==",
+                registrationName: "registration.pdf",
+                facultyListUri: "data:application/pdf;base64,dGVzdA==",
+                facultyListName: "faculty.pdf",
+                applicationFormUri: "data:application/pdf;base64,dGVzdA==",
+                applicationFormName: "application.pdf",
+            };
+
+            const response = await SELF.fetch("http://local.test/memberships/institutional", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(applicationData),
+            });
+
+            const body = await response.json<any>();
+
+            expect(response.status).toBe(201);
+            expect(body).toHaveProperty("applicationId");
+            expect(body).toHaveProperty("message", "Application submitted successfully.");
+
+            const { getDb } = await import("../../src/lib/firestore");
+            const db = getDb({} as any);
+            expect(db.collection).toHaveBeenCalledWith("institutionalMemberships");
+        });
+    });
 });


### PR DESCRIPTION
This commit introduces a new API endpoint to handle applications for institutional memberships.

The new endpoint is located at `POST /memberships/institutional`.

The implementation follows the existing pattern for endpoints in the project, using `chanfana` and `zod` for schema validation.

The endpoint performs the following actions:
- Validates the incoming application data.
- Uploads four documents (Letter of Intent, SEC/CDA Registration, Faculty List, Application Form) to GitHub.
- Creates a new record in the `institutionalMemberships` collection in Firestore.

An integration test has been added to verify the functionality of the new endpoint. The test mocks the external services (GitHub and Firestore) to ensure that the endpoint logic is correct.