### PR TITLE
feat: add schema validation to user creation endpoint

### DIFF
--- a/tests/integration/users.test.ts
+++ b/tests/integration/users.test.ts
@@ -122,10 +122,12 @@ describe("User API Integration Tests", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(invalidUserData),
       });
-      const body = await response.json();
+      const body = await response.json<any>();
 
       expect(response.status).toBe(400);
-      expect(body).toEqual({ error: "Missing required fields" });
+      expect(body.success).toBe(false);
+      expect(Array.isArray(body.errors)).toBe(true);
+      expect(body.errors[0].path).toContain("email");
     });
   });
 


### PR DESCRIPTION
Refactors the `userCreate` endpoint to use `chanfana`'s `OpenAPIRoute` class.

This change introduces a Zod schema for the request body, which validates the presence and format of `username` and `email`.

The handler now uses `getValidatedData()` for automatic request validation, removing the manual validation logic.

The integration test for invalid input has been updated to reflect the new error response format from `chanfana`.