### PR TITLE
feat: send confirmation emails for institutional memberships

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
         "chanfana": "2.8.1",
         "firebase-rest-firestore": "^1.5.0",
         "hono": "4.8.2",
+        "nodemailer": "^7.0.5",
         "zod": "3.25.67"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "0.8.44",
         "@types/node": "24.0.4",
+        "@types/nodemailer": "^6.4.17",
         "typescript": "5.8.3",
         "wrangler": "4.21.x"
       }
@@ -1913,6 +1915,16 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -2585,6 +2597,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/ohash": {
@@ -3776,9 +3797,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
     "chanfana": "2.8.1",
     "firebase-rest-firestore": "^1.5.0",
     "hono": "4.8.2",
+    "nodemailer": "^7.0.5",
     "zod": "3.25.67"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "0.8.44",
     "@types/node": "24.0.4",
+    "@types/nodemailer": "^6.4.17",
     "typescript": "5.8.3",
     "wrangler": "4.21.x"
   }

--- a/src/endpoints/memberships/institutionalMembershipCreate.ts
+++ b/src/endpoints/memberships/institutionalMembershipCreate.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { AppContext } from '../../types';
 import { uploadToGitHub } from '../../lib/github-upload';
 import { getDb } from "../../lib/firestore";
+import nodemailer from 'nodemailer';
 
 const InputSchema = z.object({
     institutionName: z.string().min(2),
@@ -25,6 +26,49 @@ const OutputSchema = z.object({
     applicationId: z.string(),
     message: z.string(),
 });
+
+async function sendEmail(env: any, to: string, subject: string, body: string, attachments?: {filename: string, content: string}[]) {
+    if (!env.EMAIL_USER || !env.EMAIL_PASS) {
+        console.log('------- EMAIL_USER or EMAIL_PASS not set in .env file. Simulating email. -------');
+        console.log(`To: ${to}`);
+        console.log(`Subject: ${subject}`);
+        console.log(`Body: ${body}`);
+        if (attachments) {
+          console.log(`${attachments.length} attachment(s) logged.`);
+        }
+        console.log('---------------------------------------------------------------------------------');
+        return;
+    }
+
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: env.EMAIL_USER,
+        pass: env.EMAIL_PASS,
+      },
+    });
+
+    const mailOptions: nodemailer.SendMailOptions = {
+      from: `PACUIT Membership <${env.EMAIL_USER}>`,
+      to,
+      subject,
+      html: body.replace(/\n/g, '<br>'),
+      attachments: attachments?.map(att => ({
+        filename: att.filename,
+        content: att.content.split("base64,")[1],
+        encoding: 'base64',
+        contentType: att.content.split(';')[0].split(':')[1]
+      }))
+    };
+
+    try {
+      const info = await transporter.sendMail(mailOptions);
+      console.log(`Email sent successfully to ${to}. Message ID: ${info.messageId}`);
+    } catch (error) {
+      console.error(`Failed to send email to ${to}:`, error);
+      throw new Error('Failed to send confirmation email.');
+    }
+}
 
 export class InstitutionalMembershipCreate extends OpenAPIRoute {
     schema = {
@@ -93,9 +137,64 @@ export class InstitutionalMembershipCreate extends OpenAPIRoute {
             ],
         });
 
+        // Admin Notification Email
+        const adminEmailSubject = `New Institutional Membership Application: ${institutionName}`;
+        const adminEmailBody = `
+A new application for institutional membership has been submitted.
+
+Application ID: ${applicationId}
+Institution Name: ${institutionName}
+Contact Person: ${contactPerson}
+Email: ${email}
+Contact Number: ${contactNumber}
+
+All required documents are attached.
+        `;
+
+        // User Confirmation Email
+        const userEmailSubject = `PACUIT Institutional Membership Application Received - ID: ${applicationId}`;
+        const userEmailBody = `
+Dear ${contactPerson},
+
+Thank you for your interest in joining the Philippine Association of Colleges and Universities of Industrial Technology (PACUIT), Inc.
+
+Your application for institutional membership for ${institutionName} has been received. Your unique application ID is ${applicationId}.
+
+Our secretariat will review your submission and get back to you within 5-7 working days regarding the status of your application.
+
+We appreciate your interest in becoming part of our network.
+
+Sincerely,
+The PACUIT Secretariat
+        `;
+
+        const adminAttachments = [
+          { filename: letterOfIntentName, content: letterOfIntentUri },
+          { filename: registrationName, content: registrationUri },
+          { filename: facultyListName, content: facultyListUri },
+          { filename: applicationFormName, content: applicationFormUri },
+        ];
+
+        // Send emails
+        await Promise.all([
+            sendEmail(
+                c.env,
+                'pacuit.info@gmail.com', // Admin email
+                adminEmailSubject,
+                adminEmailBody,
+                adminAttachments
+            ),
+            sendEmail(
+                c.env,
+                email,
+                userEmailSubject,
+                userEmailBody
+            )
+        ]);
+
         return c.json({
             applicationId,
-            message: 'Application submitted successfully.',
+            message: 'Application submitted successfully. A confirmation email has been sent.',
         }, 201);
     }
 }

--- a/tests/integration/memberships.test.ts
+++ b/tests/integration/memberships.test.ts
@@ -99,7 +99,7 @@ describe("Memberships API Integration Tests", () => {
 
             expect(response.status).toBe(201);
             expect(body).toHaveProperty("applicationId");
-            expect(body).toHaveProperty("message", "Application submitted successfully.");
+            expect(body).toHaveProperty("message", "Application submitted successfully. A confirmation email has been sent.");
 
             const { getDb } = await import("../../src/lib/firestore");
             const db = getDb({} as any);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,9 @@
+import { vi } from 'vitest';
+
+vi.mock('nodemailer', () => ({
+  default: {
+    createTransport: vi.fn(() => ({
+      sendMail: vi.fn().mockResolvedValue({ messageId: 'mock-message-id' }),
+    })),
+  },
+}));

--- a/tests/vitest.config.mts
+++ b/tests/vitest.config.mts
@@ -5,6 +5,7 @@ export default defineWorkersConfig({
     target: "esnext",
   },
   test: {
+    setupFiles: ["./tests/setup.ts"],
     poolOptions: {
       workers: {
         singleWorker: true,


### PR DESCRIPTION
Adds email sending functionality to the institutional membership application process.

When an institutional membership application is successfully submitted, the system now sends two emails:
- A notification email to the admin ('pacuit.info@gmail.com') with the application details and attached documents.
- A confirmation email to the applicant.

This is implemented using nodemailer. The test suite has been updated to mock nodemailer and to reflect changes in the API response.